### PR TITLE
Add boolean support to createAssertions helper

### DIFF
--- a/lib/helpers/createAssertions.ts
+++ b/lib/helpers/createAssertions.ts
@@ -8,6 +8,8 @@ export async function createAssertions(object: object, paramName = "body"): Prom
       console.log(`expect(${paramName}.${key}).toBeNull();`);
     } else if (typeof value === "number") {
       console.log(`expect(${paramName}.${key}).toBe(${value});`);
+    } else if (typeof value === "boolean") {
+      console.log(`expect(${paramName}.${key}).toBe(${value});`);
     } else if (typeof value === "object") {
       if (Array.isArray(value)) {
         if (value.length === 0) {


### PR DESCRIPTION
### Motivation
- Generated test assertions previously did not handle boolean values which caused `true`/`false` fields to be omitted from expectations.
- Including booleans ensures the assertion generator produces complete checks for response objects.

### Description
- Added a new branch in `createAssertions` to detect `boolean` values and emit `expect(...).toBe(<value>);` assertions.
- The change was made in `lib/helpers/createAssertions.ts` and follows the existing pattern used for numbers and strings.

### Testing
- No automated tests were run for this change.
- Manual inspection of the generated assertion output was used to validate the emitted boolean expectation format.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69545eeddcf48323a8ba1b7c9c310fc1)